### PR TITLE
Logic Error in log file opening

### DIFF
--- a/lib/forever/base.rb
+++ b/lib/forever/base.rb
@@ -23,7 +23,7 @@ module Forever
 
         File.open(pid, "w") { |f| f.write(Process.pid.to_s) }
 
-        stream      = exists?(log) ? File.new(log, "w") : '/dev/null'
+        stream      = log ? File.new(log, "w") : File.open('/dev/null', 'w')
         stream.sync = true
 
         STDOUT.reopen(stream)


### PR DESCRIPTION
I've changed the logic to instead redirect to /dev/null if the log is nil,
and otherwise open the requested file for writing. If the file doesn't exist,
it should be created, just as the pid is unconditionally created.
