### PR TITLE
Updated Thor dependency.

### DIFF
--- a/foreverb.gemspec
+++ b/foreverb.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = %w(lib)
-  s.add_dependency 'thor', '~>0.14.6'
+  s.add_dependency 'thor', '~>0.16.0'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
The Thor version dependency was conflicting with another Gem I was using, preventing me from using Foreverb. I've updated it to the latest version, which has sorted the problem for me, but perhaps you could just loosen off the version requirement?

Also, I've added Rspec to the gemspec, which seemed to be a dependency.

All specs are running.
