### PR TITLE
Fix markup formatting issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,19 +417,23 @@ esac
 
 You'll have to create one script per each user foreverb runs on.
 After creating the file, make it executable:
-```chmod +x /etc/init.d/foreverb-username
-```
+
+    chmod +x /etc/init.d/foreverb-username
+
 and add it to the system's boot:
 
 * RedHat:
   ```sudo /sbin/chkconfig --level 345 foreverb-username on
   ```
+
 * Debian/Ubuntu:
   ```sudo /usr/sbin/update-rc.d -f foreverb-username defaults
   ```
+
 * Gentoo:
   ```sudo rc-update add foreverb-username default
   ```
+
 
 ## Extras
 


### PR DESCRIPTION
The markup seemed valid but Github wasn't parsing it correctly. The alternate code block syntax fixed it though.
