### PR TITLE
Fixing crash when set ':at' parameter such as "12:"

### DIFF
--- a/lib/forever/job.rb
+++ b/lib/forever/job.rb
@@ -42,6 +42,7 @@ module Forever
         raise "#{at} must be a string" unless at.is_a?(String)
         raise "#{at} has not a colon separator" unless at =~ /:/
         hour, min = at.split(":")
+        min = '' if min.nil?
         raise "Failed to parse #{at}" if hour.to_i >= 24 || min.to_i >= 60
         [hour, min]
       end


### PR DESCRIPTION
When I set a scheduling with foreverb, an error occurred and the program crashed.

The program is:

``` ruby
require 'forever'

Forever.run do
    every 1.minute, :at => '12:' do
        puts 'Lunch!!'
    end
end
```

And crash log is:

```
/var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/job.rb:35:in `block in time?': undefined method `empty?' for nil:NilClass (NoMethodError)
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/job.rb:35:in `each'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/job.rb:35:in `any?'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/job.rb:35:in `time?'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/base.rb:103:in `block (2 levels) in initialize'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/base.rb:102:in `each'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/base.rb:102:in `block in initialize'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/base.rb:353:in `maybe_fork'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever/base.rb:70:in `initialize'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever.rb:18:in `new'
        from /var/lib/gems/1.9.1/gems/foreverb-0.3.3/lib/forever.rb:18:in `run'
        from lunch.rb:3:in `<main>'
```

So I check the file "job.rb" and then, found a problem and subsequently fixed it.
The problem occurred with `.split()` method of String.
`":00".split(":")` returns `["", "00"]`, but `"12:".split(":")` returns `["12"]`.
Therefore, a value of @ at variable becomes ["12", nil] by a function named `parse_at` and NoMethodError occurred with `at[1].empty?` in job.rb at line 35.
I fixed it using simple method. If you don't like this solution, simply reject this pull-request.
Thanks.
